### PR TITLE
Added additional tests

### DIFF
--- a/tests/testthat/test-languageEntropy.R
+++ b/tests/testthat/test-languageEntropy.R
@@ -16,11 +16,12 @@ percent_interval = 5
 
 ## compute entropy
 cols <- colnames(likerts %>% select(contains("_prop")))
+percents.colslist <- languageEntropy(percents, id = sub, base=base, colsList = list(percent=c("L1_prop","L2_prop")))
 likerts <- languageEntropy(likerts, id = sub, !!cols, contextName = "prop", base = base)
 percents <- languageEntropy(percents, id = sub, L1_prop, L2_prop, contextName = "percent", base=base)
+
 # should run an entropy computation by hand and cross check with the function
 #### HERE
-
 # ## TEST for equality between by hand entropy and languageEntropy()
 # likerts$entropy_test <- likerts$prop.entropy == likerts$p.entropy
 #
@@ -40,11 +41,21 @@ test_that("min entropy is 0", {
   expect_equal(min(likerts$prop.entropy, na.rm=T), 0)
 })
 
-
 duppercents <- rbind(percents, percents[percents$sub=="15",])
-
 # TEST that languageEntropy throws error with duplicate subjects
 test_that("languageEntropy throws error with duplicate subjects",{
   expect_error(languageEntropy(duppercents, id = sub, L1_prop, L2_prop, contextName = "percent", base=base),
                "You have duplicate identifiers in your data: 15")
+})
+
+# See if we catch the warning when not specifying context name
+test_that("languageEntropy throws a warning when user doesn't specify contextName",{
+  expect_warning(languageEntropy(percents, id = sub, L1_prop, L2_prop, base=base),
+                 "You didn't name your usage context by supplying a 'contextName' argument. I'm going to name your context 'mycontext.' Note if this happens again, your entropy value will be overwritten, so it is better to give an actual name."
+                 )
+})
+
+# Compare results of languageEntropy w/ colsList to w/o colsList
+test_that("check that results are the same w/ and w/o using colsList argument",{
+  expect_equal(percents, percents.colslist)
 })

--- a/tests/testthat/test-likert2prop.R
+++ b/tests/testthat/test-likert2prop.R
@@ -26,10 +26,10 @@ likerts.prop$measure <- paste0("p",likerts.prop$measure)
 likerts.prop <- likerts.prop %>% select(-value) %>% spread(measure, prop)
 
 likerts <- left_join(likerts, likerts.prop)
-
+likerts.bak <- likerts
 rm(likerts.prop)
 
-## compute proportions using likert2prop()
+## compute proportions using likert2prop() specifying cols
 likerts <- likert2prop(data = likerts, id = sub, !!cols, minLikert = min_likert)
 
 ## get equality between proportions computed here and proportions computed by likert2prop()
@@ -54,3 +54,32 @@ test_that("likert2prop catches the duplicate subject we added",{
   expect_error(likert2prop(duplikerts, sub, L1, L2, L3),
                "You have duplicate identifiers in your data: 15")
 })
+
+
+## compute proportions using likert2prop() specifying colsList
+likerts <- likerts.bak
+likerts <- likert2prop(data = likerts, id = sub, minLikert = min_likert, colsList = list(c("L1","L2","L3")))
+
+## get equality between proportions computed here and proportions computed by likert2prop()
+likerts$prop_test <- (likerts$pL1_rb==likerts$L1_prop) & (likerts$pL2_rb==likerts$L2_prop)
+
+test_that("proportions computed equal actual expected propotions",{
+  expect_equal(likerts$pL1_rb, likerts$L1_prop)
+  expect_equal(likerts$pL2_rb, likerts$L2_prop)
+  expect_equal(likerts$pL3_rb, likerts$L3_prop)
+})
+
+## TEST that there should be 1 NA, since as the sub with every likert at baseline will be undefined
+test_that("there is 1 subject in the dataset who had likerts at baseline thus NANs",{
+  expect_equal(length(likerts$L1_prop[is.nan(likerts$L1_prop)]), 1)
+  expect_equal(length(likerts$L2_prop[is.nan(likerts$L2_prop)]), 1)
+  expect_equal(length(likerts$L3_prop[is.nan(likerts$L3_prop)]), 1)
+})
+
+duplikerts <- rbind(likerts, likerts[likerts$sub=="15",])
+# TEST that likert2prop throws error with duplicate subjects
+test_that("likert2prop catches the duplicate subject we added",{
+  expect_error(likert2prop(duplikerts, sub, L1, L2, L3),
+               "You have duplicate identifiers in your data: 15")
+})
+


### PR DESCRIPTION
Now test the use (or not) of `colsList` argument in `languageEntropy()` and `likert2prop()`.